### PR TITLE
Add an action input `extra-files`, of extra files to copy across to the website

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           dry-run: true
           repository: ${{ matrix.package }}
+          extra-files: "CHANGES.md:copied_files/CHANGELOG.md,tst/:copied_files/test_files,tst,CHANGES.md"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ All of the following inputs are optional.
 - `dry-run`:
   - Set to `true` to create an archive containing the website instead of pushing to the `gh-pages` branch.
   - default: `false`
+- `extra-files`:
+  - Set to a non-empty string to specify files and directories to copy from the package repository to the website.
+  - The string should be comma-separated list of colon-separated pairs of files and/or directories of the form `source:destination` to be copied from the package to the `gh-pages` branch (relative to the root directory, in both cases).
+    - For example, setting the `extra-files` option to `d1/f1:D1/F1,d2:D2/D3` will copy the file `d1/f1` and the directory `d2`, respectively, from the package repository to the file `D1/F2` and to the directory `D2/D3/` of the `gh-pages` branch, creating new directories as necessary.
+    - For example, setting the `extra-files` option to `CHANGES.md,help/README-extra.md` will copy the files `CHANGES.md` and `help/README-extra.md` from the package repository to the `gh-pages` branch with the same names and path structures.
 
 ### Example
 
@@ -68,6 +73,11 @@ on:
         required: false
         type: boolean
         default: false
+      extra-files:
+        description: 'A comma-separated list of colon-separated pairs of files and/or directories to be copied from the package to the gh-pages branch'
+        required: false
+        type: string
+        default: ''
 
 permissions: write-all
 

--- a/action.yml
+++ b/action.yml
@@ -117,17 +117,20 @@ runs:
         run: |
           for PAIR in $(echo "${{ inputs.extra-files }}" | tr "," "\n"); do
 
-            SRC=$(echo  ${PAIR} | cut -d':' -f1)
-            DEST=$(echo ${PAIR} | cut -d':' -f2)
+            SRC="$(echo ${PAIR} | cut -d':' -f1)"
+            DST="$(echo ${PAIR} | cut -d':' -f2)"
+            if [ "${DST}" == "" ]; then
+              DST="${SRC}"
+            fi
 
             if [ -d "${TMP_DIR}/${SRC}" ] ; then
-              echo "Copying directory ${TMP_DIR}/${SRC} to ./$DEST"
-              mkdir -p $(dirname "${DEST}")
-              cp -r ${TMP_DIR}/${SRC} ./${DEST}
+              echo "Copying directory ${TMP_DIR}/${SRC} to ./$DST"
+              mkdir -p "$(dirname "${DST}")"
+              cp -R "${TMP_DIR}/${SRC}" "./${DST}"
             elif [ -f "${TMP_DIR}/${SRC}" ] ; then
-              echo "Copying file ${TMP_DIR}/${SRC} to ./${DEST}"
-              mkdir -p $(dirname "${DEST}")
-              cp -f ${TMP_DIR}/${SRC} ./${DEST}
+              echo "Copying file ${TMP_DIR}/${SRC} to ./${DST}"
+              mkdir -p "$(dirname "${DST}")"
+              cp -f "${TMP_DIR}/${SRC}" "./${DST}"
             else
               echo "File/directory ${TMP_DIR}/${SRC} not found"
               exit 1

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "The repository to update"
     required: false
     default: "${{ github.repository }}"
+  extra-files:
+    description: "A comma-separated list of colon-separated pairs of files and/or directories to be copied from the package to the gh-pages branch (relative to the root directory in both cases), e.g. 'd1/f1:D1/F1,d2/:D2/D3/' copies the file d1/f1 to D1/F2 in gh-pages, and copies the directory d2/ to D2/D3/ in gh-pages."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -105,6 +109,30 @@ runs:
             mkdir -p doc
             cp -r "$TMP_DIR/doc/htm" doc/
           fi
+
+      - name: "Copy extra files from the release"
+        shell: bash 
+        working-directory: gh-pages
+        if: ${{ inputs.extra-files != '' }}
+        run: |
+          for PAIR in $(echo "${{ inputs.extra-files }}" | tr "," "\n"); do
+
+            SRC=$(echo  ${PAIR} | cut -d':' -f1)
+            DEST=$(echo ${PAIR} | cut -d':' -f2)
+
+            if [ -d "${TMP_DIR}/${SRC}" ] ; then
+              echo "Copying directory ${TMP_DIR}/${SRC} to ./$DEST"
+              mkdir -p $(dirname "${DEST}")
+              cp -r ${TMP_DIR}/${SRC} ./${DEST}
+            elif [ -f "${TMP_DIR}/${SRC}" ] ; then
+              echo "Copying file ${TMP_DIR}/${SRC} to ./${DEST}"
+              mkdir -p $(dirname "${DEST}")
+              cp -f ${TMP_DIR}/${SRC} ./${DEST}
+            else
+              echo "File/directory ${TMP_DIR}/${SRC} not found"
+              exit 1
+            fi
+          done
           
       - name: "Update links in docs"
         shell: bash


### PR DESCRIPTION
I have tested this on a fake new version of the Digraphs package on my fork of Digraphs, where I have instructed it to additionally copy across the `CHANGELOG.md` file (which is what I actually want to happen in the long term), and as a test, to copy across the `tst/` directory of the package, renamed as `new/subdirectories/`.

It worked!

I ran it both as a dry-run, which produced the artifact on this Workflow run at https://github.com/wilfwilson/Digraphs/actions/runs/17469545825 (I'm not sure how long that will be around for, but for now you can verify that it does contain the extra files that it should).

And I've also just run it now where it actually pushed to my `wilfwilson/Digraphs@gh-pages` branch, see https://github.com/wilfwilson/Digraphs/actions/runs/17470173439; the branch contains both `CHANGELOG.md` and the `new/subdirectories/` directory; see https://github.com/wilfwilson/Digraphs/tree/gh-pages.

Closes #7.