### PR TITLE
Checkout within action to avoid relying on "external" checkout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,17 +21,17 @@ jobs:
       # the order of the checkout actions is important because all contents of
       # the target folder of the checkout action is removed
       - name: "Clone the package"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ${{ matrix.package }}
 
       - name: "Check out this repository"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: .this-action/
 
       - name: "Setup GAP"
-        uses: gap-actions/setup-gap@v2
+        uses: gap-actions/setup-gap@v3
           
       - name: "Build the GitHub pages"
         uses: ./.this-action/

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: gap-actions/setup-gap@v2
+      - uses: actions/checkout@v6
+      - uses: gap-actions/setup-gap@v3
       - uses: gap-actions/update-gh-pages@v1
 ```
 
@@ -92,8 +92,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: gap-actions/setup-gap@v2
+      - uses: actions/checkout@v6
+      - uses: gap-actions/setup-gap@v3
       - uses: gap-actions/update-gh-pages@v1
         with:
           version: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
         validate_boolean "${{ inputs.clean }}" clean
 
     # We explicitly do a fresh checkout so we don't rely on prevous workflow steps
-    # Until actions/checkout/issues/2318 is fixed, stick to v5
+    # Until https://github.com/actions/checkout/issues/2318 is fixed, stick to v5
     - name: "Checkout"
       uses: actions/checkout@v5
       with:

--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,17 @@ runs:
         validate_boolean "${{ inputs.dry-run }}" dry-run
         validate_boolean "${{ inputs.clean }}" clean
 
+    # We explicitly do a fresh checkout so we don't rely on prevous workflow steps
+    # Until actions/checkout/issues/2318 is fixed, stick to v5
+    - name: "Checkout"
+      uses: actions/checkout@v5
+      with:
+        path: gh-pages-tmpdir
+        repository: ${{ inputs.repository }}
+
     - name: "Setup git"
       shell: bash
+      working-directory: gh-pages-tmpdir
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
@@ -49,6 +58,7 @@ runs:
 
     - name: "Create gh-pages worktree"
       shell: bash
+      working-directory: gh-pages-tmpdir
       run: |
         if [[ -z $(git ls-remote --heads origin gh-pages) ]]; then
           echo "::warning::No existing 'gh-pages' branch was found, so it was created. You will still need to change the Pages settings of your repository."
@@ -62,7 +72,7 @@ runs:
     - name: "Setup GitHubPagesForGAP"
       shell: bash
       if: ${{ inputs.clean == 'true' }}
-      working-directory: gh-pages
+      working-directory: gh-pages-tmpdir/gh-pages
       run: |
         # Remove everything
         git rm -r --cached --ignore-unmatch *
@@ -106,7 +116,7 @@ runs:
 
     - name: "Copy files from the release"
       shell: bash
-      working-directory: gh-pages
+      working-directory: gh-pages-tmpdir/gh-pages
       run: |
         cp -f $TMP_DIR/PackageInfo.g .
         cp -f $TMP_DIR/$README .
@@ -127,7 +137,7 @@ runs:
 
     - name: "Copy extra files from the release"
       shell: bash 
-      working-directory: gh-pages
+      working-directory: gh-pages-tmpdir/gh-pages
       if: ${{ inputs.extra-files != '' }}
       run: |
         for PAIR in $(echo "${{ inputs.extra-files }}" | tr "," "\n"); do
@@ -154,7 +164,7 @@ runs:
 
     - name: "Update links in docs"
       shell: bash
-      working-directory: gh-pages
+      working-directory: gh-pages-tmpdir/gh-pages
       run: |
         if [ -d "doc" ] ; then
           cd doc
@@ -172,14 +182,14 @@ runs:
 
     - name: "Run update script"
       shell: bash
-      working-directory: gh-pages
+      working-directory: gh-pages-tmpdir/gh-pages
       run: |
         GAPROOT=${GAPROOT-$HOME/gap}
         $GAPROOT/gap update.g
 
     - name: "Update the gh-pages branch"
       shell: bash
-      working-directory: gh-pages
+      working-directory: gh-pages-tmpdir/gh-pages
       if: ${{ inputs.dry-run == 'false' }}
       run: |
         git add -A
@@ -190,7 +200,7 @@ runs:
       if: ${{ inputs.dry-run == 'true' }}
       uses: actions/jekyll-build-pages@v1
       with:
-        source: gh-pages
+        source: gh-pages-tmpdir/gh-pages
         destination: output
 
     - name: "Upload the release"


### PR DESCRIPTION
Resolves #12

Instead of relying on the checkout of the workflow, we do a checkout inside the action. This should be more robust, as we don't get impacted by breaking changes when bumping `actions/checkout` in the workflow, nor by the workflow deleting e.g. the `.git` folder.

Currently uses `actions/checkout@v5`, but should probably be updated once `v6` correctly sets credentials for worktrees.